### PR TITLE
Updating environment configuration files to use conda-forge.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,12 @@
 name: my_project
 
 channels:
-  - simpleitk
+  # Avoiding defaults channel if possible so as not to require a paid license
+  # if it isn't necessary.
+  # Organizations with 200 or more people (e.g. a university outside the context of a course)
+  # is required to have a paid license to access the defaults channel and use the
+  # Anaconda distribution.
+  # https://www.anaconda.com/blog/is-conda-free
+  - conda-forge
 dependencies:
   - SimpleITK>=2.1.0

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,8 +1,12 @@
 name: my_project_dev
 
 channels:
-  - defaults
-  - simpleitk
+  # Avoiding defaults channel if possible so as not to require a paid license
+  # if it isn't necessary.
+  # Organizations with 200 or more people (e.g. a university outside the context of a course)
+  # is required to have a paid license to access the defaults channel and use the
+  # Anaconda distribution.
+  # https://www.anaconda.com/blog/is-conda-free
   - conda-forge
 dependencies:
   - SimpleITK>=2.0.0


### PR DESCRIPTION
Avoid using the defaults channel if possible. The usage of the defaults channel may require a licensed version of the Anaconda distribution, so avoid when possible.